### PR TITLE
Added fields to some snippets

### DIFF
--- a/content templates/after.sublime-snippet
+++ b/content templates/after.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:after></perch:after>]]></content>
+	<content><![CDATA[<perch:after>$0</perch:after>]]></content>
 	<tabTrigger>perchafter</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/before.sublime-snippet
+++ b/content templates/before.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:before></perch:before>]]></content>
+	<content><![CDATA[<perch:before>$0</perch:before>]]></content>
 	<tabTrigger>perchbefore</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/block.sublime-snippet
+++ b/content templates/block.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:block type="" label=""></perch:block>]]></content>
+	<content><![CDATA[<perch:block type="$1" label="$2">$0</perch:block>]]></content>
 	<tabTrigger>perchblock</tabTrigger>
 	<scope>source.php, text.html</scope>
 </snippet>

--- a/content templates/blocks.sublime-snippet
+++ b/content templates/blocks.sublime-snippet
@@ -1,5 +1,9 @@
 <snippet>
-	<content><![CDATA[<perch:blocks><perch:block type="" label=""></perch:block></perch:blocks>]]></content>
+	<content>
+<![CDATA[<perch:blocks>
+	<perch:block type="$1" label="$2">$0</perch:block>
+</perch:blocks>]]>
+	</content>
 	<tabTrigger>perchblocks</tabTrigger>
 	<scope>source.php, text.html</scope>
 </snippet>

--- a/content templates/content.sublime-snippet
+++ b/content templates/content.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:content id="" type="" label=""/>]]></content>
+	<content><![CDATA[<perch:content id="$1" type="$2" label="$3"/>]]></content>
 	<tabTrigger>perchcontent</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/every.sublime-snippet
+++ b/content templates/every.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:every count="" nth-child=""></perch:every>]]></content>
+	<content><![CDATA[<perch:every count="$1" nth-child="$2">$0</perch:every>]]></content>
 	<tabTrigger>perchevery</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/help.sublime-snippet
+++ b/content templates/help.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:help></perch:help>]]></content>
+	<content><![CDATA[<perch:help>$1</perch:help>]]></content>
 	<tabTrigger>perchhelp</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/if.sublime-snippet
+++ b/content templates/if.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:if exists=""></perch:if>]]></content>
+	<content><![CDATA[<perch:if exists="$1">$0</perch:if>]]></content>
 	<tabTrigger>perchif</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/ifelse.sublime-snippet
+++ b/content templates/ifelse.sublime-snippet
@@ -1,5 +1,7 @@
 <snippet>
-	<content><![CDATA[<perch:if exists=""><perch:else/></perch:if>]]></content>
+	<content>
+<![CDATA[<perch:if exists="$1">$2<perch:else/>$3</perch:if>]]>
+	</content>
 	<tabTrigger>perchifelse</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/layout.sublime-snippet
+++ b/content templates/layout.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:layout path="" />]]></content>
+	<content><![CDATA[<perch:layout path="$1"/>]]></content>
 	<tabTrigger>perchlayout</tabTrigger>
 	<scope>text.html, source.php</scope>
 </snippet>

--- a/content templates/noresults.sublime-snippet
+++ b/content templates/noresults.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:noresults></perch:noresults>]]></content>
+	<content><![CDATA[<perch:noresults>$1</perch:noresults>]]></content>
 	<tabTrigger>perchnoresults</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/repeater.sublime-snippet
+++ b/content templates/repeater.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[<perch:repeater id="" label="" max="" scope-parent="">
-	</perch:repeater>]]></content>
+	<content>
+<![CDATA[<perch:repeater id="$1" label="$2" max="$3" scope-parent="$4">$0</perch:repeater>]]></content>
 	<tabTrigger>perchrepeater</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/search.sublime-snippet
+++ b/content templates/search.sublime-snippet
@@ -1,7 +1,5 @@
 <snippet>
-	<content><![CDATA[
-		<perch:search id="" />
-		]]></content>
+	<content><![CDATA[<perch:search id="$1"/>]]></content>
 	<tabTrigger>perchsearch</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/showall.sublime-snippet
+++ b/content templates/showall.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:showall />]]></content>
+	<content><![CDATA[<perch:showall/>]]></content>
 	<tabTrigger>perchshowall</tabTrigger>
 	<scope>text.html</scope>
 </snippet>

--- a/content templates/template.sublime-snippet
+++ b/content templates/template.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[<perch:template path="" rescope=""/>]]></content>
+	<content><![CDATA[<perch:template path="$1" rescope="$2"/>]]></content>
 	<tabTrigger>perchtemplate</tabTrigger>
 	<scope>text.html</scope>
 </snippet>


### PR DESCRIPTION
I was using the content template snippets and found having the [Fields](http://docs.sublimetext.info/en/latest/extensibility/snippets.html?highlight=snippets#fields) set up for them really handy.
I also added some indentation for a couple of the nested ones, eg. `<perch:blocks>`
